### PR TITLE
Fixing not so random randomizing

### DIFF
--- a/presentation/components/matches/matched-players/index.tsx
+++ b/presentation/components/matches/matched-players/index.tsx
@@ -12,9 +12,8 @@ interface MatchedPlayersProps {
 const MatchedPlayersGames: React.FC<MatchedPlayersProps> = ({
 	selectedPlayers
 }) => {
-	const [matchedPlayers, setMatchedPlayers] = React.useState<
-		Array<MatchedPlayers>
-	>()
+	const [matchedPlayers, setMatchedPlayers] =
+		React.useState<Array<MatchedPlayers>>()
 
 	React.useEffect(() => {
 		setMatchedPlayers(randomPlayerPairings(selectedPlayers))

--- a/presentation/components/util/random-player-pairings.ts
+++ b/presentation/components/util/random-player-pairings.ts
@@ -5,6 +5,8 @@ const randomPlayerPairings = (playersList: Player[]): MatchedPlayers[] => {
 	const splitPlayersAndShuffle = (
 		playersList: Player[]
 	): { arr1: Player[]; arr2: Player[] } => {
+		// initial shuffle before split
+		playersList.sort(() => 0.5 - Math.random())
 		const arr1 = playersList
 			.slice(0, playersList.length / 2)
 			.sort(() => 0.5 - Math.random())
@@ -38,7 +40,6 @@ const randomPlayerPairings = (playersList: Player[]): MatchedPlayers[] => {
 			player2: arr2.pop()
 		})
 	}
-	console.log('matchedPlayersList: ', matchedPlayersList)
 	return matchedPlayersList
 }
 


### PR DESCRIPTION
resolves #19 

Was only shuffling after splitting the array, so as long as the array was the same initially, the 2 halves would always be the same.

Now, shuffling the array before even splitting allows for more guaranteed randomization